### PR TITLE
Replace ReflectionType's deprecated __toString() with getName()

### DIFF
--- a/src/ImmutableRecordLogic.php
+++ b/src/ImmutableRecordLogic.php
@@ -299,7 +299,10 @@ trait ImmutableRecordLogic
                 );
             }
 
-            $type = (string) $method->getReturnType();
+            /** @var \ReflectionNamedType $returnType */
+            $returnType = $method->getReturnType();
+
+            $type = $returnType->getName();
 
             $propTypeMap[$prop->getName()] = [$type, self::isScalarType($type), $method->getReturnType()->allowsNull()];
         }


### PR DESCRIPTION
[`ReflectionType::__toString()`](https://www.php.net/manual/en/reflectiontype.tostring.php) is deprecated since PHP 7.1 and its usage triggers warnings, eg. when running tests with PHPUnit.

Closes #1