### PR TITLE
use php7.4 functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.4",
     "roave/security-advisories": "dev-master"
   },
   "require-dev": {

--- a/src/ImmutableRecordLogic.php
+++ b/src/ImmutableRecordLogic.php
@@ -277,34 +277,9 @@ trait ImmutableRecordLogic
                 continue;
             }
 
-            if (! $refObj->hasMethod($prop->getName())) {
-                throw new \RuntimeException(
-                    \sprintf(
-                        'No method found for Record property %s of %s that has the same name.',
-                        $prop->getName(),
-                        __CLASS__
-                    )
-                );
-            }
+            $type = $prop->getType();
 
-            $method = $refObj->getMethod($prop->getName());
-
-            if (! $method->hasReturnType()) {
-                throw new \RuntimeException(
-                    \sprintf(
-                        'Method %s of Record %s does not have a return type',
-                        $method->getName(),
-                        __CLASS__
-                    )
-                );
-            }
-
-            /** @var \ReflectionNamedType $returnType */
-            $returnType = $method->getReturnType();
-
-            $type = $returnType->getName();
-
-            $propTypeMap[$prop->getName()] = [$type, self::isScalarType($type), $method->getReturnType()->allowsNull()];
+            $propTypeMap[$prop->getName()] = [(string) $type, self::isScalarType((string) $type), $type->allowsNull()];
         }
 
         return $propTypeMap;


### PR DESCRIPTION
Hi,

I've used the new type hinting functionality for properties in PHP 7.4 to create more efficient ImmutableRecords. 

But the only problem is that it would give conflicts if people still use older PHP versions. Maybe you can create a dev branch for the PHP 7.4 functionality or merge this branch in master and create a dev branch for people who want to use older PHP versions?

What are your taughts about the last problem?