### PR TITLE
arrayPropItemTypeMap should be indexed with a specialKey

### DIFF
--- a/src/ImmutableRecordLogic.php
+++ b/src/ImmutableRecordLogic.php
@@ -190,9 +190,9 @@ trait ImmutableRecordLogic
                     $recordData[$key] = $val;
                     break;
                 case ImmutableRecord::PHP_TYPE_ARRAY:
-                    if (\array_key_exists($key, $arrayPropItemTypeMap) && ! self::isScalarType($arrayPropItemTypeMap[$key])) {
-                        $recordData[$key] = \array_map(function ($item) use ($key, &$arrayPropItemTypeMap) {
-                            return $this->fromType($item, $arrayPropItemTypeMap[$key]);
+                    if (\array_key_exists($specialKey, $arrayPropItemTypeMap) && ! self::isScalarType($arrayPropItemTypeMap[$specialKey])) {
+                        $recordData[$key] = \array_map(function ($item) use ($specialKey, &$arrayPropItemTypeMap) {
+                            return $this->fromType($item, $arrayPropItemTypeMap[$specialKey]);
                         }, $val);
                     } else {
                         $recordData[$key] = $val;

--- a/tests/ImmutableRecordLogicTest.php
+++ b/tests/ImmutableRecordLogicTest.php
@@ -163,6 +163,8 @@ final class ImmutableRecordLogicTest extends TestCase
             RecordWithSpecialKey::BANK_ACCOUNT => '12324434',
             RecordWithSpecialKey::SUCCESS_RATE => 33.33,
             RecordWithSpecialKey::ITEM_LIST => [['name' => 'Awesome tester'], ['name' => 'John Smith']],
+            RecordWithSpecialKey::ITEM_ARRAY => [['name' => 'Awesome tester array'], ['name' => 'John Smith array']],
+
         ];
         $specialKey = RecordWithSpecialKey::fromArray($recordArray);
         $this->assertSame($recordArray, $specialKey->toArray());
@@ -171,6 +173,12 @@ final class ImmutableRecordLogicTest extends TestCase
             RecordWithSpecialKey::BANK_ACCOUNT => $recordArray[RecordWithSpecialKey::BANK_ACCOUNT],
             RecordWithSpecialKey::SUCCESS_RATE => Percentage::fromFloat($recordArray[RecordWithSpecialKey::SUCCESS_RATE]),
             RecordWithSpecialKey::ITEM_LIST => ItemList::fromArray($recordArray[RecordWithSpecialKey::ITEM_LIST]),
+            RecordWithSpecialKey::ITEM_ARRAY => array_map(
+                static function (array $item) {
+                    return ImmutableItem::fromArray($item);
+                },
+                $recordArray[RecordWithSpecialKey::ITEM_ARRAY]
+            ),
         ]);
         $this->assertSame($recordArray, $specialKey->toArray());
     }

--- a/tests/Stub/RecordWithSpecialKey.php
+++ b/tests/Stub/RecordWithSpecialKey.php
@@ -24,6 +24,7 @@ final class RecordWithSpecialKey implements ImmutableRecord, SpecialKeySupport
     public const BANK_ACCOUNT = 'bank_account';
     public const SUCCESS_RATE = 'success_rate';
     public const ITEM_LIST = 'item_list';
+    public const ITEM_ARRAY = 'item_array';
 
     /**
      * @var string
@@ -39,6 +40,11 @@ final class RecordWithSpecialKey implements ImmutableRecord, SpecialKeySupport
      * @var ItemList
      */
     private $itemList;
+
+    /**
+     * @var array<ImmutableItem>
+     */
+    private $itemArray;
 
     /**
      * @return mixed
@@ -64,6 +70,14 @@ final class RecordWithSpecialKey implements ImmutableRecord, SpecialKeySupport
         return $this->itemList;
     }
 
+    /**
+     * @return array<ImmutableItem>
+     */
+    public function itemArray(): array
+    {
+        return $this->itemArray;
+    }
+
     public function convertKeyForRecord(string $key): string
     {
         switch ($key) {
@@ -71,6 +85,8 @@ final class RecordWithSpecialKey implements ImmutableRecord, SpecialKeySupport
                 return 'successRate';
             case self::ITEM_LIST:
                 return 'itemList';
+            case self::ITEM_ARRAY:
+                return 'itemArray';
             default:
                 return 'bankAccount';
         }
@@ -83,8 +99,17 @@ final class RecordWithSpecialKey implements ImmutableRecord, SpecialKeySupport
                 return self::SUCCESS_RATE;
             case 'itemList':
                 return self::ITEM_LIST;
+            case 'itemArray':
+                return self::ITEM_ARRAY;
             default:
                 return self::BANK_ACCOUNT;
         }
+    }
+
+    private static function arrayPropItemTypeMap(): array
+    {
+        return [
+            'itemArray' => ImmutableItem::class,
+        ];
     }
 }


### PR DESCRIPTION
I don't know if this should be merged into master. If not, let me know.

The problem was that special key support was not working for arrayPropItemTypeMap.

In the toArray function of ImmutableRecordLogic the key of arrayPropItemTypeMap should be the propertyName (the one that is converted)
while in the fromArray function the key of arrayPropItemTypeMap should be the given key (the one that is not converted).

So I changed this that the converted key is also used in the fromArray function for arrayPropItemTypeMap.

I also tested this functionality in an existing test.

